### PR TITLE
Issue #5 - mapping to an existing view model

### DIFF
--- a/src/UmbMapper/Extensions/PublishedContentExtensions.cs
+++ b/src/UmbMapper/Extensions/PublishedContentExtensions.cs
@@ -81,5 +81,41 @@ namespace UmbMapper.Extensions
 
             return mapper.Map(content);
         }
+
+        /// <summary>
+        /// Performs a mapping operation from the <see cref="IPublishedContent"/> to an existing <typeparamref name="T"/> instance
+        /// </summary>
+        /// <typeparam name="T">The type of object to map to</typeparam>
+        /// <param name="content">The content to map</param>
+        /// <param name="destination">The destination object</param>
+        public static void MapTo<T>(this IPublishedContent content, T destination)
+            where T : class
+        {
+            Type type = typeof(T);
+            MapTo(content, type, (T)destination);
+        }
+
+        /// <summary>
+        /// Performs a mapping operation from the <see cref="IPublishedContent"/> to an existing <see cref="object"/> instance
+        /// </summary>
+        /// <param name="content">The content to map</param>
+        /// <param name="type">The type of object to map to</param>
+        /// <param name="destination">The destination object</param>
+        public static void MapTo(this IPublishedContent content, Type type, object destination)
+        {
+            if (content == null)
+            {
+                throw new ArgumentNullException(nameof(content));
+            }
+
+            UmbMapperRegistry.Mappers.TryGetValue(type, out var mapper);
+
+            if (mapper == null)
+            {
+                throw new InvalidOperationException($"No mapper for the given type {type} has been registered.");
+            }
+
+            mapper.Map(content, destination);
+        }
     }
 }

--- a/src/UmbMapper/Extensions/PublishedContentExtensions.cs
+++ b/src/UmbMapper/Extensions/PublishedContentExtensions.cs
@@ -72,7 +72,7 @@ namespace UmbMapper.Extensions
                 throw new ArgumentNullException(nameof(content));
             }
 
-            UmbMapperRegistry.Mappers.TryGetValue(type, out var mapper);
+            UmbMapperRegistry.Mappers.TryGetValue(type, out IUmbMapperConfig mapper);
 
             if (mapper == null)
             {
@@ -108,7 +108,7 @@ namespace UmbMapper.Extensions
                 throw new ArgumentNullException(nameof(content));
             }
 
-            UmbMapperRegistry.Mappers.TryGetValue(type, out var mapper);
+            UmbMapperRegistry.Mappers.TryGetValue(type, out IUmbMapperConfig mapper);
 
             if (mapper == null)
             {

--- a/src/UmbMapper/FastPropertyAccessor.cs
+++ b/src/UmbMapper/FastPropertyAccessor.cs
@@ -64,7 +64,7 @@ namespace UmbMapper
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public object GetValue(string propertyName, object instance)
         {
-            return this.getterCache.TryGetValue(propertyName, out var getter)
+            return this.getterCache.TryGetValue(propertyName, out Func<object, object> getter)
                 ? getter(instance)
                 : null;
         }

--- a/src/UmbMapper/IUmbMapperConfig.cs
+++ b/src/UmbMapper/IUmbMapperConfig.cs
@@ -39,6 +39,19 @@ namespace UmbMapper
         void Map(IPublishedContent content, object destination);
 
         /// <summary>
+        /// Creates an empty instance of the mapped type.
+        /// </summary>
+        /// <returns>The <see cref="object"/></returns>
+        object CreateEmpty();
+
+        /// <summary>
+        /// Creates an empty instance of the mapped type.
+        /// </summary>
+        /// <param name="content">The published content</param>
+        /// <returns>The <see cref="object"/></returns>
+        object CreateEmpty(IPublishedContent content);
+
+        /// <summary>
         /// Runs any additional code required to setup the configuration
         /// </summary>
         void Init();

--- a/src/UmbMapper/IUmbMapperConfig.cs
+++ b/src/UmbMapper/IUmbMapperConfig.cs
@@ -25,11 +25,18 @@ namespace UmbMapper
         IEnumerable<IPropertyMap> Mappings { get; }
 
         /// <summary>
-        /// Performs the mapping operation
+        /// Performs the mapping operation creating a new destination object
         /// </summary>
         /// <param name="content">The published content</param>
         /// <returns>The <see cref="object"/></returns>
         object Map(IPublishedContent content);
+
+        /// <summary>
+        /// Performs the mapping operation onto an existing destination object
+        /// </summary>
+        /// <param name="content">The published content</param>
+        /// <param name="destination">The destination object</param>
+        void Map(IPublishedContent content, object destination);
 
         /// <summary>
         /// Runs any additional code required to setup the configuration

--- a/src/UmbMapper/Proxy/LazyInterceptor.cs
+++ b/src/UmbMapper/Proxy/LazyInterceptor.cs
@@ -25,12 +25,8 @@ namespace UmbMapper.Proxy
         /// </param>
         public LazyInterceptor(Dictionary<string, Lazy<object>> values)
         {
-            this.lazyDictionary = new Dictionary<string, Lazy<object>>();
+            this.lazyDictionary = values;
             this.nonLazyDictionary = new Dictionary<string, object>();
-            foreach (KeyValuePair<string, Lazy<object>> pair in values)
-            {
-                this.lazyDictionary.Add(pair.Key, pair.Value);
-            }
         }
 
         /// <inheritdoc />

--- a/src/UmbMapper/UmbMapperConfig{T}.cs
+++ b/src/UmbMapper/UmbMapperConfig{T}.cs
@@ -55,12 +55,12 @@ namespace UmbMapper
             Type type = typeof(T);
             this.MappedType = type;
 
-            // Check the validity of the mpped type constructor as early as possible.
+            // Check the validity of the mapped type constructor as early as possible.
             bool validConstructor = false;
             ParameterInfo[] constructorParams = this.MappedType.GetConstructorParameters();
             if (constructorParams != null)
             {
-                // Is it PublishedContentmModel or similar?
+                // Is it PublishedContentModel or similar?
                 if (constructorParams.Length == 1 && constructorParams[0].ParameterType == typeof(IPublishedContent))
                 {
                     this.hasIPublishedConstructor = true;
@@ -163,105 +163,6 @@ namespace UmbMapper
         }
 
         /// <inheritdoc/>
-        object IUmbMapperConfig.Map(IPublishedContent content)
-        {
-            object result;
-            if (this.createProxy)
-            {
-                // Create a proxy instance to replace our object.
-                result = this.hasIPublishedConstructor ? this.proxyType.GetInstance(content) : this.proxyType.GetInstance();
-
-                // Map the lazy properties and predicate mappings
-                Dictionary<string, Lazy<object>> lazyProperties = this.MapLazyProperties(content, result);
-
-                // Set the interceptor and replace our result with the proxy
-                var interceptor = new LazyInterceptor(lazyProperties);
-                ((IProxy)result).Interceptor = interceptor;
-            }
-            else
-            {
-                result = this.hasIPublishedConstructor ? this.MappedType.GetInstance(content) : this.MappedType.GetInstance();
-            }
-
-            // Users might want to use lazy loading with API controllers that do not inherit from UmbracoAPIController.
-            // Certain mappers like Archtype require the context so we want to ensure it exists.
-            EnsureUmbracoContext();
-
-            // Now map the non-lazy properties and non-lazy predicate mappings
-            this.MapNonLazyProperties(content, result);
-
-            return result;
-        }
-
-        /// <inheritdoc/>
-        public void Map(IPublishedContent content, object destination)
-        {
-            // TODO: If we're mapping to an existing object, what do we do with lazy items?
-
-            // Users might want to use lazy loading with API controllers that do not inherit from UmbracoAPIController.
-            // Certain mappers like Archtype require the context so we want to ensure it exists.
-            EnsureUmbracoContext();
-
-            // Map the non-lazy properties and non-lazy predicate mappings
-            this.MapNonLazyProperties(content, destination);
-        }
-
-        private Dictionary<string, Lazy<object>> MapLazyProperties(IPublishedContent content, object result)
-        {
-            // First add any lazy mappings, use count to prevent allocations
-            var lazyProperties = new Dictionary<string, Lazy<object>>(this.lazyNames.Count);
-            for (int i = 0; i < this.lazyMaps.Length; i++)
-            {
-                // It's better to allocate the `int` via closure than PropertyMap<T>
-                int i1 = i;
-                lazyProperties[this.lazyMaps[i].Info.Property.Name] = new Lazy<object>(() =>
-                {
-                    EnsureUmbracoContext();
-                    return MapProperty(this.lazyMaps[i1], content, result);
-                });
-            }
-
-            // Then lazy predicate mappings
-            for (int i = 0; i < this.lazyPredicateMaps.Length; i++)
-            {
-                // It's better to allocate the `int` via closure than PropertyMap<T>
-                int i1 = i;
-                lazyProperties[this.lazyPredicateMaps[i].Info.Property.Name] = new Lazy<object>(() =>
-                {
-                    EnsureUmbracoContext();
-                    return MapProperty(this.lazyPredicateMaps[i1], content, result);
-                });
-            }
-
-            return lazyProperties;
-        }
-
-        private void MapNonLazyProperties(IPublishedContent content, object destination)
-        {
-            // First map the non-lazy properties
-            for (int i = 0; i < this.nonLazyMaps.Length; i++)
-            {
-                PropertyMap<T> map = this.nonLazyMaps[i];
-                object value = MapProperty(map, content, destination);
-                if (value != null)
-                {
-                    this.propertyAccessor.SetValue(map.Info.Property.Name, destination, value);
-                }
-            }
-
-            // Then non-lazy predicate mappings
-            for (int i = 0; i < this.nonLazyPredicateMaps.Length; i++)
-            {
-                PropertyMap<T> map = this.nonLazyPredicateMaps[i];
-                object value = MapProperty(map, content, destination);
-                if (value != null)
-                {
-                    this.propertyAccessor.SetValue(map.Info.Property.Name, destination, value);
-                }
-            }
-        }
-
-        /// <inheritdoc/>
         void IUmbMapperConfig.Init()
         {
             // We run the initialization code here so we don't have to run it per mapping.
@@ -298,6 +199,91 @@ namespace UmbMapper
 
                 this.hasChecked = true;
             }
+        }
+
+        /// <inheritdoc/>
+        object IUmbMapperConfig.CreateEmpty()
+        {
+            if (this.createProxy)
+            {
+                var proxy = (IProxy)this.proxyType.GetInstance();
+                proxy.Interceptor = new LazyInterceptor(new Dictionary<string, Lazy<object>>());
+                return proxy;
+            }
+
+            return this.MappedType.GetInstance();
+        }
+
+        /// <inheritdoc/>
+        object IUmbMapperConfig.CreateEmpty(IPublishedContent content)
+        {
+            if (this.createProxy)
+            {
+                var proxy = (IProxy)this.proxyType.GetInstance(content);
+                proxy.Interceptor = new LazyInterceptor(new Dictionary<string, Lazy<object>>());
+                return proxy;
+            }
+
+            return this.MappedType.GetInstance(content);
+        }
+
+        /// <inheritdoc/>
+        object IUmbMapperConfig.Map(IPublishedContent content)
+        {
+            object result;
+            if (this.createProxy)
+            {
+                // Create a proxy instance to replace our object.
+                result = this.hasIPublishedConstructor ? this.proxyType.GetInstance(content) : this.proxyType.GetInstance();
+
+                // Map the lazy properties and predicate mappings
+                Dictionary<string, Lazy<object>> lazyProperties = this.MapLazyProperties(content, result);
+
+                // Set the interceptor and replace our result with the proxy
+                var interceptor = new LazyInterceptor(lazyProperties);
+                ((IProxy)result).Interceptor = interceptor;
+            }
+            else
+            {
+                result = this.hasIPublishedConstructor ? this.MappedType.GetInstance(content) : this.MappedType.GetInstance();
+            }
+
+            // Users might want to use lazy loading with API controllers that do not inherit from UmbracoAPIController.
+            // Certain mappers like Archetype require the context so we want to ensure it exists.
+            EnsureUmbracoContext();
+
+            // Now map the non-lazy properties and non-lazy predicate mappings
+            this.MapNonLazyProperties(content, result);
+
+            return result;
+        }
+
+        /// <inheritdoc/>
+        public void Map(IPublishedContent content, object destination)
+        {
+            // Users might want to use lazy loading with API controllers that do not inherit from UmbracoAPIController.
+            // Certain mappers like Archetype require the context so we want to ensure it exists.
+            EnsureUmbracoContext();
+
+            // We don't know whether the destination was created by UmbMapper or by something else so we have to check to see if it
+            // is a proxy instance.
+            if (destination is IProxy proxy)
+            {
+                // Map the lazy properties and predicate mappings
+                Dictionary<string, Lazy<object>> lazyProperties = this.MapLazyProperties(content, destination);
+
+                // Replace the interceptor with our new one.
+                var interceptor = new LazyInterceptor(lazyProperties);
+                proxy.Interceptor = interceptor;
+            }
+            else
+            {
+                // Map our collated lazy properties as non-lazy instead.
+                this.MapLazyPropertiesAsNonLazy(content, destination);
+            }
+
+            // Map the non-lazy properties and non-lazy predicate mappings
+            this.MapNonLazyProperties(content, destination);
         }
 
         /// <summary>
@@ -453,6 +439,86 @@ namespace UmbMapper
                 UmbracoConfig.For.UmbracoSettings(),
                 UrlProviderResolver.Current.Providers,
                 false);
+        }
+
+        private Dictionary<string, Lazy<object>> MapLazyProperties(IPublishedContent content, object result)
+        {
+            // First add any lazy mappings, use count to prevent allocations
+            var lazyProperties = new Dictionary<string, Lazy<object>>(this.lazyNames.Count);
+            for (int i = 0; i < this.lazyMaps.Length; i++)
+            {
+                // It's better to allocate the `int` via closure than PropertyMap<T>
+                int i1 = i;
+                lazyProperties[this.lazyMaps[i].Info.Property.Name] = new Lazy<object>(() =>
+                {
+                    EnsureUmbracoContext();
+                    return MapProperty(this.lazyMaps[i1], content, result);
+                });
+            }
+
+            // Then lazy predicate mappings
+            for (int i = 0; i < this.lazyPredicateMaps.Length; i++)
+            {
+                // It's better to allocate the `int` via closure than PropertyMap<T>
+                int i1 = i;
+                lazyProperties[this.lazyPredicateMaps[i].Info.Property.Name] = new Lazy<object>(() =>
+                {
+                    EnsureUmbracoContext();
+                    return MapProperty(this.lazyPredicateMaps[i1], content, result);
+                });
+            }
+
+            return lazyProperties;
+        }
+
+        private void MapNonLazyProperties(IPublishedContent content, object destination)
+        {
+            // First map the non-lazy properties
+            for (int i = 0; i < this.nonLazyMaps.Length; i++)
+            {
+                PropertyMap<T> map = this.nonLazyMaps[i];
+                object value = MapProperty(map, content, destination);
+                if (value != null)
+                {
+                    this.propertyAccessor.SetValue(map.Info.Property.Name, destination, value);
+                }
+            }
+
+            // Then non-lazy predicate mappings
+            for (int i = 0; i < this.nonLazyPredicateMaps.Length; i++)
+            {
+                PropertyMap<T> map = this.nonLazyPredicateMaps[i];
+                object value = MapProperty(map, content, destination);
+                if (value != null)
+                {
+                    this.propertyAccessor.SetValue(map.Info.Property.Name, destination, value);
+                }
+            }
+        }
+
+        private void MapLazyPropertiesAsNonLazy(IPublishedContent content, object destination)
+        {
+            // First map the lazy properties
+            for (int i = 0; i < this.lazyMaps.Length; i++)
+            {
+                PropertyMap<T> map = this.lazyMaps[i];
+                object value = MapProperty(map, content, destination);
+                if (value != null)
+                {
+                    this.propertyAccessor.SetValue(map.Info.Property.Name, destination, value);
+                }
+            }
+
+            // Then lazy predicate mappings
+            for (int i = 0; i < this.lazyPredicateMaps.Length; i++)
+            {
+                PropertyMap<T> map = this.lazyPredicateMaps[i];
+                object value = MapProperty(map, content, destination);
+                if (value != null)
+                {
+                    this.propertyAccessor.SetValue(map.Info.Property.Name, destination, value);
+                }
+            }
         }
 
         private bool GetOrCreateMap(PropertyInfo property, out PropertyMap<T> map)

--- a/src/UmbMapper/UmbMapperRegistry.cs
+++ b/src/UmbMapper/UmbMapperRegistry.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using Umbraco.Core.Models;
 
 namespace UmbMapper
 {
@@ -64,6 +65,45 @@ namespace UmbMapper
             ((IUmbMapperConfig)config).Init();
 
             Mappers.TryAdd(config.MappedType, config);
+        }
+
+        /// <summary>
+        /// Creates an empty instance of the given type.
+        /// If the configuration for the type contains lazy mappings a transparent proxy is returned.
+        /// </summary>
+        /// <typeparam name="T">The type of object to create</typeparam>
+        /// <returns>The <typeparamref name="T"/></returns>
+        public static T CreateEmpty<T>()
+            where T : class
+        {
+            Mappers.TryGetValue(typeof(T), out IUmbMapperConfig mapper);
+
+            if (mapper == null)
+            {
+                throw new InvalidOperationException($"No mapper for the given type {typeof(T)} has been registered.");
+            }
+
+            return (T)mapper.CreateEmpty();
+        }
+
+        /// <summary>
+        /// Creates an empty instance of the given type.
+        /// If the configuration for the type contains lazy mappings a transparent proxy is returned.
+        /// </summary>
+        /// <typeparam name="T">The type of object to create</typeparam>
+        /// <param name="content">The content that this instance will map from.</param>
+        /// <returns>The <typeparamref name="T"/></returns>
+        public static T CreateEmpty<T>(IPublishedContent content)
+            where T : class
+        {
+            Mappers.TryGetValue(typeof(T), out IUmbMapperConfig mapper);
+
+            if (mapper == null)
+            {
+                throw new InvalidOperationException($"No mapper for the given type {typeof(T)} has been registered.");
+            }
+
+            return (T)mapper.CreateEmpty(content);
         }
 
         /// <summary>

--- a/tests/UmbMapper.Tests/Mapping/BasicMappingTests.cs
+++ b/tests/UmbMapper.Tests/Mapping/BasicMappingTests.cs
@@ -247,5 +247,37 @@ namespace UmbMapper.Tests.Mapping
             Assert.Contains(result.Polymorphic, x => x.PolyMorphicText == "Foo");
             Assert.Contains(result.Polymorphic, x => x.PolyMorphicText == "Bar");
         }
+
+        [Fact]
+        public void MapperCanMapToExistingInstance()
+        {
+            const int id = 999;
+            const string name = "Foo";
+            var created = new DateTime(2017, 1, 1);
+            PlaceOrder placeOrder = PlaceOrder.Second;
+
+            MockPublishedContent content = this.support.Content;
+            content.Id = id;
+            content.Name = name;
+            content.CreateDate = created;
+            content.Properties = new List<IPublishedProperty>
+            {
+                new MockPublishedContentProperty(nameof(PublishedItem.PlaceOrder), PlaceOrder.Fourth)
+            };
+
+            PublishedItem result = UmbMapperRegistry.CreateEmpty<PublishedItem>();
+
+            // Set a value before mapping.
+            result.PlaceOrder = placeOrder;
+
+            content.MapTo(result);
+
+            Assert.Equal(id, result.Id);
+            Assert.Equal(name, result.Name);
+            Assert.Equal(created, result.CreateDate);
+
+            // We expect it to be overwritten
+            Assert.NotEqual(placeOrder, result.PlaceOrder);
+        }
     }
 }

--- a/tests/UmbMapper.Tests/Mapping/LazyMappingTests.cs
+++ b/tests/UmbMapper.Tests/Mapping/LazyMappingTests.cs
@@ -1,6 +1,10 @@
-﻿using UmbMapper.Extensions;
+﻿using System;
+using System.Collections.Generic;
+using UmbMapper.Extensions;
 using UmbMapper.Proxy;
 using UmbMapper.Tests.Mapping.Models;
+using UmbMapper.Tests.Mocks;
+using Umbraco.Core.Models;
 using Xunit;
 
 namespace UmbMapper.Tests.Mapping
@@ -32,6 +36,39 @@ namespace UmbMapper.Tests.Mapping
             Assert.IsAssignableFrom<IProxy>(result);
             Assert.NotNull(result.Slug);
             Assert.True(result.Slug == result.Name.ToLowerInvariant());
+        }
+
+        [Fact]
+        public void MapperCanMapToExistingInstance()
+        {
+            const int id = 999;
+            const string name = "Foo";
+            var created = new DateTime(2017, 1, 1);
+            PlaceOrder placeOrder = PlaceOrder.Second;
+
+            MockPublishedContent content = this.support.Content;
+            content.Id = id;
+            content.Name = name;
+            content.CreateDate = created;
+            content.Properties = new List<IPublishedProperty>
+            {
+                new MockPublishedContentProperty(nameof(PublishedItem.PlaceOrder), PlaceOrder.Fourth)
+            };
+
+
+            LazyPublishedItem result = UmbMapperRegistry.CreateEmpty<LazyPublishedItem>();
+
+            // Set a value before mapping.
+            result.PlaceOrder = placeOrder;
+
+            content.MapTo(result);
+
+            Assert.Equal(id, result.Id);
+            Assert.Equal(name, result.Name);
+            Assert.Equal(created, result.CreateDate);
+
+            // We expect it to be overwritten
+            Assert.NotEqual(placeOrder, result.PlaceOrder);
         }
     }
 }


### PR DESCRIPTION
Partial PR for issue #5

Here have created extensions on `IPublishedContent` and methods on `IUmbMapperConfig` to support mapping to an existing object.

As mentioned on the issue, there's a pending `TODO:` around how lazy properties might be handled in this scenario.  Not sure whether it's feasible to recreate the passed object as a proxy?  Not something I'm particularly familiar with really, so likely best if you think the feature request is a good idea and PR so far worth building on, you consider how that might be handled.